### PR TITLE
Fix deployment to mlab-oti

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -4,17 +4,17 @@
     "sandbox": "mlab-sandbox"
   },
   "targets": {
-    "mlab-sandbox": {
+    "mlab-oti": {
       "hosting": {
-        "mlab-sandbox": [
+        "speedtest": [
           "mlab-speedtest"
         ]
       }
     },
-    "mlab-oti": {
+    "mlab-sandbox": {
       "hosting": {
-        "mlab-oti": [
-          "mlab-speedtest"
+        "speedtest": [
+          "mlab-sandbox"
         ]
       }
     }

--- a/.firebaserc
+++ b/.firebaserc
@@ -13,7 +13,7 @@
     },
     "mlab-oti": {
       "hosting": {
-        "mlab-speedtest": [
+        "mlab-oti": [
           "mlab-speedtest"
         ]
       }

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ deploy:
     secure: r1cRKzr4oBC7mUuXamslr9dCWCjyPj4Kyn84wg5jSQhPj3Qg43zGzd98IIxr3rM3chPtpRg4yX579HCXDh4cqUI98qdzrKZqctxiphmOpAIppgJxKWomUIY9/W0V0Ysn3ft9uJA1X5OcJDqH9C4bU+ZHSrohwzW6h8xDTf52HXinuybZD/GzwzEstj41fNWnwyVq1TT47zC/FutkFqY07ZvIp4ocp8OcBMBTGtxepNs6/ekL4W+8tR/LSTByRKEu2/MSuMMUIFtSV2tjZ0G7JkbaV9ig/vBG27gimcrqo/RS3aZ0ylRrKvYT5HlRNAsq1xYpKBk5nj0iji9xcfx3HBtVXM6S4mMB2RnO8I8httok+bfu3a08wAARPrqY+CW7C+2UvYcJM6adYT7/QhIxKTrGl5vzc9bCpRkGnXX45+xEtvXd2L3YctpG80r8FiGtewDmpu/U+Lc5YnGvzRaTQThcUNtmRBVnHKtgiVCOH8cz3hPBkvzmQBNzUhJCKzpcBtogfr+QHshJne3Q4qd74C0J4Gh4VkSTcQjVVpOHpCV/iJt4RnVTs58viyKeEfFChRJs6G3BQDo4cPBrESuBCQLWDZyoWuetkMQFC4LYK2IL1RxGpZ+Hw2J2L3j3RT04zu65b5P/gWr+YLymgsTr4FhQEj8Rd+boMnAxHo9u9D8=
   project: mlab-oti
   edge: true
-  only: hosting:mlab-speedtest
+  only: hosting:mlab-oti
   on:
     repo: m-lab/mlab-speedtest  
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ deploy:
     secure: r1cRKzr4oBC7mUuXamslr9dCWCjyPj4Kyn84wg5jSQhPj3Qg43zGzd98IIxr3rM3chPtpRg4yX579HCXDh4cqUI98qdzrKZqctxiphmOpAIppgJxKWomUIY9/W0V0Ysn3ft9uJA1X5OcJDqH9C4bU+ZHSrohwzW6h8xDTf52HXinuybZD/GzwzEstj41fNWnwyVq1TT47zC/FutkFqY07ZvIp4ocp8OcBMBTGtxepNs6/ekL4W+8tR/LSTByRKEu2/MSuMMUIFtSV2tjZ0G7JkbaV9ig/vBG27gimcrqo/RS3aZ0ylRrKvYT5HlRNAsq1xYpKBk5nj0iji9xcfx3HBtVXM6S4mMB2RnO8I8httok+bfu3a08wAARPrqY+CW7C+2UvYcJM6adYT7/QhIxKTrGl5vzc9bCpRkGnXX45+xEtvXd2L3YctpG80r8FiGtewDmpu/U+Lc5YnGvzRaTQThcUNtmRBVnHKtgiVCOH8cz3hPBkvzmQBNzUhJCKzpcBtogfr+QHshJne3Q4qd74C0J4Gh4VkSTcQjVVpOHpCV/iJt4RnVTs58viyKeEfFChRJs6G3BQDo4cPBrESuBCQLWDZyoWuetkMQFC4LYK2IL1RxGpZ+Hw2J2L3j3RT04zu65b5P/gWr+YLymgsTr4FhQEj8Rd+boMnAxHo9u9D8=
   project: mlab-oti
   edge: true
-  only: hosting:mlab-oti
+  only: hosting:speedtest
   on:
     repo: m-lab/mlab-speedtest  
     tags: true
@@ -23,7 +23,7 @@ deploy:
     secure: r1cRKzr4oBC7mUuXamslr9dCWCjyPj4Kyn84wg5jSQhPj3Qg43zGzd98IIxr3rM3chPtpRg4yX579HCXDh4cqUI98qdzrKZqctxiphmOpAIppgJxKWomUIY9/W0V0Ysn3ft9uJA1X5OcJDqH9C4bU+ZHSrohwzW6h8xDTf52HXinuybZD/GzwzEstj41fNWnwyVq1TT47zC/FutkFqY07ZvIp4ocp8OcBMBTGtxepNs6/ekL4W+8tR/LSTByRKEu2/MSuMMUIFtSV2tjZ0G7JkbaV9ig/vBG27gimcrqo/RS3aZ0ylRrKvYT5HlRNAsq1xYpKBk5nj0iji9xcfx3HBtVXM6S4mMB2RnO8I8httok+bfu3a08wAARPrqY+CW7C+2UvYcJM6adYT7/QhIxKTrGl5vzc9bCpRkGnXX45+xEtvXd2L3YctpG80r8FiGtewDmpu/U+Lc5YnGvzRaTQThcUNtmRBVnHKtgiVCOH8cz3hPBkvzmQBNzUhJCKzpcBtogfr+QHshJne3Q4qd74C0J4Gh4VkSTcQjVVpOHpCV/iJt4RnVTs58viyKeEfFChRJs6G3BQDo4cPBrESuBCQLWDZyoWuetkMQFC4LYK2IL1RxGpZ+Hw2J2L3j3RT04zu65b5P/gWr+YLymgsTr4FhQEj8Rd+boMnAxHo9u9D8=
   project: mlab-sandbox
   edge: true
-  only: hosting:mlab-sandbox
+  only: hosting:speedtest
   on:
     branch: sandbox-*
     condition: "$TRAVIS_EVENT_TYPE == push"

--- a/firebase.json
+++ b/firebase.json
@@ -1,9 +1,11 @@
 {
   "hosting": {
+    "target": "speedtest",
     "public": "app",
     "ignore": [
       "firebase.json",
-      "**/.*"
+      "**/.*",
+      "**/node_modules/**"
     ]
   }
 }


### PR DESCRIPTION
This PR fixes the Travis deployment to speed.measurementlab.net. 

Firebase configuration tested with:
- production: `firebase deploy --non-interactive --project="mlab-oti" --token="..." --only hosting:speedtest`
- sandbox: `firebase deploy --non-interactive --project="mlab-sandbox" --token="..." --only hosting:speedtest`