### PR TITLE
Add retransmission rate back

### DIFF
--- a/app/measure/measure.html
+++ b/app/measure/measure.html
@@ -64,13 +64,11 @@
   						<td translate>Latency</td>
   						<td><strong>{{ measurementResult.latency }}</strong></td>
   					</tr>
-<!-- Hide retransmission rate - need clarity on how to calc.this value from TCPINFO           
             <tr>
               <td><i class="fa fa-signal" aria-hidden="true"></i></td>
   						<td translate>Retransmission</td>
   						<td><strong>{{ measurementResult.loss }}</strong></td>
   					</tr>
--->            
   				</table>
         </div>
     </section>

--- a/app/measure/measure.js
+++ b/app/measure/measure.js
@@ -94,7 +94,7 @@ angular.module('Measure.Measure', ['ngRoute'])
           's2cRate': downloadSpeed().toFixed(2) + ' Mb/s',
           'c2sRate': uploadSpeed().toFixed(2) + ' Mb/s',
           'latency': readNDTvar('MinRTT') + ' ms',
-          'loss': String((readNDTvar('loss') * 100).toFixed(2)) + "%"
+          'loss': String((readNDTvar('TCPInfo.BytesRetrans') / readNDTvar("TCPInfo.BytesSent") * 100).toFixed(2)) + "%"
         };
         ndtSemaphore = false;
         $scope.startButtonClass = '';


### PR DESCRIPTION
The calculation is made by dividing `BytesRetrans`/`BytesSent`, as seen by the sender during the S2C (download) test.