### PR TITLE
add safari browser check and notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 * Install website build dependencies for your operating system and environment
   * Node >= v10.15.1 - Using NVM: `nvm install v10.15.1`
   * Gulp - Installed with `yarn`
+  * Install libraries - `gulp copy_libs`
   * Firebase tools - `npm install -g firebase-tools`
 
 ## Adding new languages
@@ -35,7 +36,6 @@ Translations for this site are managed in the [Open Technology Fund's Localizati
 
 To preview the site locally, we recommend using the Python Simple HTTP Server. 
 
-* From the root directory run `bower install`
 * Navigate to the `/app` directory and run: `python3 -m http.server 8000`
 
 If you are a user on the M-Lab Firebase project, you can also preview the site locally using the firebase-cli: `firebase serve --only hosting:mlab-speedtest`

--- a/app/app.js
+++ b/app/app.js
@@ -5,7 +5,8 @@ angular.module('Measure', [
   'ngRoute',
   'gettext',
   'Measure.Measure',
-  'Measure.GaugeService'
+  'Measure.GaugeService',
+  'ng.deviceDetector'
 ])
 
 .value('ndtServer', {})

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,6 +1,18 @@
 @import url(font-awesome.min.css);
 
 /* Custom */
+.featureWarning {
+	margin: auto;
+	width: 50%;
+}
+
+.featureWarning p {
+	margin: 1em;
+	padding: 2em;
+	font-size: 4em;
+	text-align: center;
+	color:white;
+}
 
 table.transparent {
 	background: none;

--- a/app/index.html
+++ b/app/index.html
@@ -56,9 +56,12 @@
 		<script src="assets/js/main.js"></script>
 
 	  <script type="text/javascript" src="libraries/ndt7.min.js"></script>
+	  <script type="text/javascript" src="libraries/re-tree.min.js"></script>
+	  <script type="text/javascript" src="libraries/ua-device-detector.min.js"></script>
+	  <script type="text/javascript" src="libraries/ng-device-detector.min.js"></script>
 
-		<script src="measure/measure.js"></script>
-		<script src="services/gaugeService.js"></script>
+	  <script src="measure/measure.js"></script>
+	  <script src="services/gaugeService.js"></script>
 	  <script src="app.js"></script>
 	  <script>
 	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/app/measure/measure.html
+++ b/app/measure/measure.html
@@ -2,8 +2,7 @@
 <section id="intro" class="wrapper style1 fullscreen">
   <div class="featureWarning" ng-show="isSafari">
     <p translate>We're sorry, the Safari browser is not compatible with the NDT
-    test (<a href="#">more info</a>). Please use a different browser such as
-    Chrome or Firefox instead.</p>
+    test. Please use a different browser such as Chrome or Firefox instead.</p>
   </div>
   <div class="features">
     <section>

--- a/app/measure/measure.html
+++ b/app/measure/measure.html
@@ -1,7 +1,9 @@
 <!-- Intro -->
 <section id="intro" class="wrapper style1 fullscreen">
-  <div class="featureWarning" ng-show="unsupportedSystem">
-    <p translate>Your browser may not be compatible with the M-Lab speed test. Please update to a more current version and try again.</p>
+  <div class="featureWarning" ng-show="isSafari">
+    <p translate>We're sorry, the Safari browser is not compatible with the NDT
+    test (<a href="#">more info</a>). Please use a different browser such as
+    Chrome or Firefox instead.</p>
   </div>
   <div class="features">
     <section>
@@ -16,7 +18,9 @@
       <p>
         <div class="row">
         	<div class="6u">
-            <a class="button special startButton big" ng-click="startTest()" ng-class="{disabled: (privacyConsent !== true || startButtonClass === 'disabled')}">
+            <a class="button special startButton big" ng-click="startTest()"
+            ng-class="{disabled: (privacyConsent !== true || startButtonClass
+            === 'disabled' || isSafari )}">
               <span ng-show="!measurementComplete && startButtonClass != 'disabled'"><span translate>Begin</span> <i class="fa fa-play" aria-hidden="true"></i></span>
               <span ng-show="measurementComplete && startButtonClass != 'disabled'"><span translate>Again</span> <i class="fa fa-repeat" aria-hidden="true"></i></span>
               <span ng-show="startButtonClass == 'disabled'"><span translate>Testing</span> <i class="fa fa-circle-o-notch" aria-hidden="true"></i></span>

--- a/app/measure/measure.js
+++ b/app/measure/measure.js
@@ -3,11 +3,16 @@
 angular.module('Measure.Measure', ['ngRoute'])
 
 .controller('MeasureCtrl', function($scope, $rootScope, $interval, $timeout,
-    gettextCatalog, ndtServer, ProgressGauge) {
+    gettextCatalog, ndtServer, ProgressGauge, deviceDetector) {
 
   var ndtSemaphore = false;
 
   $scope.measurementComplete = false;
+
+  $scope.isSafari = deviceDetector.browser === "safari";
+  $scope.isFirefox = deviceDetector.browser === "firefox";
+  
+  console.log(deviceDetector);
 
   ProgressGauge.create();
   $scope.currentPhase = '';
@@ -17,7 +22,7 @@ angular.module('Measure.Measure', ['ngRoute'])
     var gaugeProgress,
         TIME_EXPECTED = 10;
 
-    if ($scope.privacyConsent !== true) {
+    if ($scope.privacyConsent !== true || $scope.isSafari ) {
       return;
     }
 

--- a/app/measure/measure.js
+++ b/app/measure/measure.js
@@ -10,7 +10,6 @@ angular.module('Measure.Measure', ['ngRoute'])
   $scope.measurementComplete = false;
 
   $scope.isSafari = deviceDetector.browser === "safari";
-  $scope.isFirefox = deviceDetector.browser === "firefox";
   
   console.log(deviceDetector);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,8 @@ gulp.task('copy_libs', function() {
   gulp.src([
     "./node_modules/@m-lab/ndt7/src/*.min.js",
   ])
-    .pipe(gulp.dest('./app/libraries'));
+
+  .pipe(gulp.dest('./app/libraries'));
 
   gulp.src([
     "./node_modules/ua-device-detector/ua-device-detector.min.js",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,4 +40,11 @@ gulp.task('copy_libs', function() {
     "./node_modules/@m-lab/ndt7/src/*.min.js",
   ])
     .pipe(gulp.dest('./app/libraries'));
-});
+
+  gulp.src([
+    "./node_modules/ua-device-detector/ua-device-detector.min.js",
+    "./node_modules/ng-device-detector/ng-device-detector.min.js",
+    "./node_modules/re-tree/re-tree.min.js",   
+  ])
+    .pipe(gulp.dest('./app/libraries'));
+  });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
     "@bower_components/html5-boilerplate": "h5bp/html5-boilerplate#^5.3.0",
     "@bower_components/jquery": "jquery/jquery-dist#3.0.0",
     "@bower_components/skel": "n33/skel#~3.0.1",
-    "@m-lab/ndt7": "0.0.2"
+    "@m-lab/ndt7": "0.0.2",
+    "ng-device-detector": "^5.1.4",
+    "re-tree": "^0.1.7",
+    "ua-device-detector": "^1.1.8"
   },
   "engines": {
     "yarn": ">= 1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -363,6 +363,7 @@ bower@^1.8.8:
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -492,6 +493,7 @@ clone-stats@^0.0.1:
 clone@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/clone/-/clone-0.2.0.tgz#c6126a90ad4f72dbf5acdb243cc37724fe93fc1f"
+  integrity sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=
 
 clone@^1.0.0, clone@^1.0.2:
   version "1.0.4"
@@ -647,6 +649,7 @@ deep-extend@^0.6.0:
 defaults@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
   dependencies:
     clone "^1.0.2"
 
@@ -684,6 +687,7 @@ depd@~1.1.2:
 deprecated@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/deprecated/-/deprecated-0.0.1.tgz#f9c9af5464afa1e7a971458a8bdef2aa94d5bb19"
+  integrity sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -775,6 +779,7 @@ encoding@0.1.12:
 end-of-stream@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-0.1.5.tgz#8e177206c3c80837d85632e8b9359dfe8b2f6eaf"
+  integrity sha1-jhdyBsPICDfYVjLouTWd/osvbq8=
   dependencies:
     once "~1.3.0"
 
@@ -1007,6 +1012,7 @@ finalhandler@1.1.0:
 find-index@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/find-index/-/find-index-0.1.1.tgz#675d358b2ca3892d795a1ab47232f8b6e2e0dde4"
+  integrity sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=
 
 findup-sync@^2.0.0:
   version "2.0.0"
@@ -1030,6 +1036,7 @@ fined@^1.0.1:
 first-chunk-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
+  integrity sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=
 
 flagged-respawn@^1.0.0:
   version "1.0.1"
@@ -1122,6 +1129,7 @@ gauge@~2.7.3:
 gaze@^0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/gaze/-/gaze-0.5.2.tgz#40b709537d24d1d45767db5a908689dfe69ac44f"
+  integrity sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=
   dependencies:
     globule "~0.1.0"
 
@@ -1163,6 +1171,7 @@ glob-parent@^2.0.0:
 glob-stream@^3.1.5:
   version "3.1.18"
   resolved "https://registry.yarnpkg.com/glob-stream/-/glob-stream-3.1.18.tgz#9170a5f12b790306fdfe598f313f8f7954fd143b"
+  integrity sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=
   dependencies:
     glob "^4.3.1"
     glob2base "^0.0.12"
@@ -1174,12 +1183,14 @@ glob-stream@^3.1.5:
 glob-watcher@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/glob-watcher/-/glob-watcher-0.0.6.tgz#b95b4a8df74b39c83298b0c05c978b4d9a3b710b"
+  integrity sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=
   dependencies:
     gaze "^0.5.1"
 
 glob2base@^0.0.12:
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/glob2base/-/glob2base-0.0.12.tgz#9d419b3e28f12e83a362164a277055922c9c0d56"
+  integrity sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=
   dependencies:
     find-index "^0.1.1"
 
@@ -1193,6 +1204,7 @@ glob@^3.2.11:
 glob@^4.3.1:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f"
+  integrity sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -1213,6 +1225,7 @@ glob@^7.0.0, glob@^7.1.3:
 glob@~3.1.21:
   version "3.1.21"
   resolved "https://registry.yarnpkg.com/glob/-/glob-3.1.21.tgz#d29e0a055dea5138f4d07ed40e8982e83c2066cd"
+  integrity sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=
   dependencies:
     graceful-fs "~1.2.0"
     inherits "1"
@@ -1249,6 +1262,7 @@ global-prefix@^1.0.1:
 globule@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/globule/-/globule-0.1.0.tgz#d9c8edde1da79d125a151b79533b978676346ae5"
+  integrity sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=
   dependencies:
     glob "~3.1.21"
     lodash "~1.0.1"
@@ -1261,10 +1275,11 @@ glogg@^1.0.0:
     sparkles "^1.0.0"
 
 graceful-fs@^3.0.0:
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-3.0.11.tgz#7613c778a1afea62f25c630a086d7f3acbbdd818"
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-3.0.12.tgz#0034947ce9ed695ec8ab0b854bc919e82b1ffaef"
+  integrity sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==
   dependencies:
-    natives "^1.1.0"
+    natives "^1.1.3"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.15"
@@ -1273,6 +1288,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
 graceful-fs@~1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.2.3.tgz#15a4806a57547cb2d2dbf27f42e89a8c3451b364"
+  integrity sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=
 
 group-array@^0.3.0:
   version "0.3.3"
@@ -1323,6 +1339,7 @@ gulp-serve@^1.4.0:
 gulp-util@^3.0.0, gulp-util@^3.0.7:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
+  integrity sha1-AFTh50RQLifATBh8PsxQXdVLu08=
   dependencies:
     array-differ "^1.0.0"
     array-uniq "^1.0.2"
@@ -1346,6 +1363,7 @@ gulp-util@^3.0.0, gulp-util@^3.0.7:
 gulp@^3.9.1:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/gulp/-/gulp-3.9.1.tgz#571ce45928dd40af6514fc4011866016c13845b4"
+  integrity sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=
   dependencies:
     archy "^1.0.0"
     chalk "^1.0.0"
@@ -1524,6 +1542,7 @@ inflight@^1.0.4:
 inherits@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-1.0.2.tgz#ca4309dadee6b54cc0b8d247e8d7c7a0975bdc9b"
+  integrity sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=
 
 inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
@@ -1534,8 +1553,9 @@ ini@^1.3.4, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
 interpret@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 is-absolute@^1.0.0:
   version "1.0.0"
@@ -1711,6 +1731,7 @@ is-unc-path@^1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+  integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -1879,6 +1900,7 @@ kind-of@^6.0.0, kind-of@^6.0.2:
 liftoff@^2.1.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-2.5.0.tgz#2009291bb31cea861bbf10a7c15a28caf75c31ec"
+  integrity sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=
   dependencies:
     extend "^3.0.0"
     findup-sync "^2.0.0"
@@ -1991,6 +2013,7 @@ lodash@^4.17.11, lodash@^4.17.5:
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
+  integrity sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=
 
 log4js@^0.6.31:
   version "0.6.38"
@@ -2108,12 +2131,14 @@ minimatch@0.3:
 minimatch@^2.0.1:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
+  integrity sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=
   dependencies:
     brace-expansion "^1.0.0"
 
 minimatch@~0.2.11:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.2.14.tgz#c74e780574f63c6f9a090e90efbe6ef53a6a756a"
+  integrity sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=
   dependencies:
     lru-cache "2"
     sigmund "~1.0.0"
@@ -2194,9 +2219,10 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-natives@^1.1.0:
+natives@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 needle@^2.2.1:
   version "2.2.4"
@@ -2209,6 +2235,14 @@ needle@^2.2.1:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+ng-device-detector@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ng-device-detector/-/ng-device-detector-5.1.4.tgz#c72d536b9a691f33ff8ecded0d70889ec0d2f166"
+  integrity sha512-FnnxnRFj3KMSCC/4yS469z3qQ5FtLLxtnCp1dPk6gGtddqGJZVrGN46bBGdJ/jjxhcPi0V9dSARFjspVW1LguA==
+  dependencies:
+    re-tree "^0.1.7"
+    ua-device-detector "^1.1.1"
 
 node-fetch@^2.6.0:
   version "2.6.1"
@@ -2355,6 +2389,7 @@ once@^1.3.0:
 once@~1.3.0:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
+  integrity sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=
   dependencies:
     wrappy "1"
 
@@ -2372,6 +2407,7 @@ options@>=0.0.5:
 orchestrator@^0.3.0:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/orchestrator/-/orchestrator-0.3.8.tgz#14e7e9e2764f7315fbac184e506c7aa6df94ad7e"
+  integrity sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=
   dependencies:
     end-of-stream "~0.1.5"
     sequencify "~0.0.7"
@@ -2380,6 +2416,7 @@ orchestrator@^0.3.0:
 ordered-read-streams@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz#fd565a9af8eb4473ba69b6ed8a34352cb552f126"
+  integrity sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -2582,6 +2619,11 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+re-tree@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/re-tree/-/re-tree-0.1.7.tgz#fc3070b583fcc42d61a47e47f6c5bcd01bc9087d"
+  integrity sha512-K+W48N/KKwBVK8J4BeAxySAueWhMGTcvN2VpXv7lXQzDTc4iJb2TfgeMEvTu+Bpb3kGvj/jMDo0HKYWvb9G2lg==
+
 readable-stream@1.1, readable-stream@~1.1.9:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
@@ -2594,6 +2636,7 @@ readable-stream@1.1, readable-stream@~1.1.9:
 "readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.2:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -2771,6 +2814,7 @@ semver@5.3.0, semver@^5.3.0:
 semver@^4.1.0, semver@~4.3.3:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+  integrity sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=
 
 semver@~5.0.1:
   version "5.0.3"
@@ -2797,6 +2841,7 @@ send@0.16.2:
 sequencify@~0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/sequencify/-/sequencify-0.0.7.tgz#90cff19d02e07027fd767f5ead3e7b95d1e7380c"
+  integrity sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=
 
 serve-static@^1.11.1:
   version "1.13.2"
@@ -3007,6 +3052,7 @@ stream-combiner@^0.2.2:
 stream-consume@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/stream-consume/-/stream-consume-0.1.1.tgz#d3bdb598c2bd0ae82b8cac7ac50b1107a7996c48"
+  integrity sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==
 
 stream-to-array@^2.3.0:
   version "2.3.0"
@@ -3045,6 +3091,7 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
 strip-bom@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-1.0.0.tgz#85b8862f3844b5a6d5ec8467a93598173a36f794"
+  integrity sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=
   dependencies:
     first-chunk-stream "^1.0.0"
     is-utf8 "^0.2.0"
@@ -3072,6 +3119,7 @@ tar@^4:
 through2@^0.6.1:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
+  integrity sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=
   dependencies:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
@@ -3090,6 +3138,7 @@ through@2, through@^2.3.8, through@~2.3, through@~2.3.4:
 tildify@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tildify/-/tildify-1.2.0.tgz#dcec03f55dca9b7aa3e5b04f21817eb56e63588a"
+  integrity sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=
   dependencies:
     os-homedir "^1.0.0"
 
@@ -3163,6 +3212,13 @@ typescript@~2.3.2:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.4.tgz#3d38321828231e434f287514959c37a82b629f42"
 
+ua-device-detector@^1.1.1, ua-device-detector@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ua-device-detector/-/ua-device-detector-1.1.8.tgz#3048c0cec4634629bd6a90ea9756f0fe1bebf35d"
+  integrity sha512-G+nSDgos024vrvPEYQjE4mkAFd4KZxzSQEB3uFqpAYpdaUjGjAyNdLn2GQn4KKCG+ay7ABKrk3hfcwjEVXIVag==
+  dependencies:
+    re-tree "^0.1.7"
+
 ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
@@ -3192,6 +3248,7 @@ union-value@^1.0.0:
 unique-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-stream/-/unique-stream-1.0.0.tgz#d59a4a75427447d9aa6c91e70263f8d26a4b104b"
+  integrity sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -3215,6 +3272,7 @@ use@^3.1.0:
 user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
+  integrity sha1-K1viOjK2Onyd640PKNSFcko98ZA=
 
 useragent@^2.1.6:
   version "2.3.0"
@@ -3234,6 +3292,7 @@ utils-merge@1.0.1:
 v8flags@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
+  integrity sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=
   dependencies:
     user-home "^1.1.1"
 
@@ -3248,6 +3307,7 @@ verror@1.10.0:
 vinyl-fs@^0.3.0:
   version "0.3.14"
   resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-0.3.14.tgz#9a6851ce1cac1c1cea5fe86c0931d620c2cfa9e6"
+  integrity sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=
   dependencies:
     defaults "^1.0.0"
     glob-stream "^3.1.5"
@@ -3261,6 +3321,7 @@ vinyl-fs@^0.3.0:
 vinyl@^0.4.0:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-0.4.6.tgz#2f356c87a550a255461f36bbeb2a5ba8bf784847"
+  integrity sha1-LzVsh6VQolVGHza76ypbqL94SEc=
   dependencies:
     clone "^0.2.0"
     clone-stats "^0.0.1"
@@ -3335,7 +3396,12 @@ xmlhttprequest-ssl@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz#185a888c04eca46c3e4070d99f7b49de3528992d"
 
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
This PR adds the ng-browser-detect module, a check for Safari, and a notification about unsupported browser. Also disables the ability to run the test in Safari.