### PR TITLE
Unwrap warning message

### DIFF
--- a/app/measure/measure.html
+++ b/app/measure/measure.html
@@ -1,8 +1,7 @@
 <!-- Intro -->
 <section id="intro" class="wrapper style1 fullscreen">
   <div class="featureWarning" ng-show="isSafari">
-    <p translate>We're sorry, the Safari browser is not compatible with the NDT
-    test. Please use a different browser such as Chrome or Firefox instead.</p>
+    <p translate>We're sorry, the Safari browser is not compatible with the NDT test. Please use a different browser such as Chrome or Firefox instead.</p>
   </div>
   <div class="features">
     <section>

--- a/translations/source/application.pot
+++ b/translations/source/application.pot
@@ -174,7 +174,5 @@ msgid "Want to participate in M-Lab?"
 msgstr ""
 
 #: measure.html:4
-msgid ""
-"We're sorry, the Safari browser is not compatible with the NDT\n"
-"    test. Please use a different browser such as Chrome or Firefox instead."
+msgid "We're sorry, the Safari browser is not compatible with the NDT test. Please use a different browser such as Chrome or Firefox instead."
 msgstr ""


### PR DESCRIPTION
The warning message for Safari appears to be somewhat mangled in the translation template file due to manual newlines in the file it's sourced from. This PR removes the newlines and updates application.pot to correspond with the change.