### PR TITLE
Fix mailto link

### DIFF
--- a/app/measure/measure.html
+++ b/app/measure/measure.html
@@ -123,7 +123,7 @@
         <ul class="contact">
           <li>
             <h3 translate>Email</h3>
-            <a href="mailto: support@measurementlab.net">support@measurementlab.net</a>
+            <a href="mailto:support@measurementlab.net">support@measurementlab.net</a>
           </li>
           <li>
             <h3 translate>Discussion and Notification Group</h3>


### PR DESCRIPTION
`mailto:` should not be followed by a whitespace character -- this is converted to `mailto:%20support@measurementlab.net` when following the link.