### PR TITLE
Add multiple scenarios for BBR-terminated testing

### DIFF
--- a/app/measure/measure.js
+++ b/app/measure/measure.js
@@ -220,6 +220,7 @@ angular.module('Measure.Measure', ['ngRoute'])
         {
           userAcceptedDataPolicy: true,
           downloadworkerfile: "/libraries/pt-download-worker.min.js",
+          // Randomly choose to run one of the configurations above.
           metadata: md[Math.floor(Math.random()*md.length)]
         },
         {

--- a/app/measure/measure.js
+++ b/app/measure/measure.js
@@ -186,15 +186,41 @@ angular.module('Measure.Measure', ['ngRoute'])
     }
 
     async function runPT(sid) {
+      var md = [
+          {
+            client_name: "speed-measurementlab-net",
+            client_session_id: sid,
+            max_cwnd_gain: "512",
+          },
+          {
+            client_name: "speed-measurementlab-net",
+            client_session_id: sid,
+            max_elapsed_time: "5",
+          },
+          {
+            client_name: "speed-measurementlab-net",
+            client_session_id: sid,
+            max_cwnd_gain: "512",
+            max_elapsed_time: "5",
+          },
+          {
+            client_name: "speed-measurementlab-net",
+            client_session_id: sid,
+            early_exit: "50",
+          },
+          {
+            client_name: "speed-measurementlab-net",
+            client_session_id: sid,
+            max_cwnd_gain: "512",
+            early_exit: "50",
+          },
+      ]
+
       return pt.test(
         {
           userAcceptedDataPolicy: true,
           downloadworkerfile: "/libraries/pt-download-worker.min.js",
-          metadata: {
-            client_name: "speed-measurementlab-net",
-            client_session_id: sid,
-            max_cwnd_gain: "512",
-          }
+          metadata: md[Math.floor(Math.random()*md.length)]
         },
         {
           serverChosen: function (server) {

--- a/app/measure/measure.js
+++ b/app/measure/measure.js
@@ -186,7 +186,7 @@ angular.module('Measure.Measure', ['ngRoute'])
     }
 
     async function runPT(sid) {
-      var md = [
+      const md = [
           {
             client_name: "speed-measurementlab-net",
             client_session_id: sid,


### PR DESCRIPTION
This PR adds the following test exit scenarios to the BBR-terminated testing:
- BBR pipe full
- 5s duration
- BBR pipe full & 5s duration
- 50 MB
- BBR pipe full & 50 MB

The scenarios chosen on each run is randomized.

The preview is [here](https://mlab-sandbox.web.app/#/).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-speedtest/74)
<!-- Reviewable:end -->
