### PR TITLE
Add client_immediate_exit option to BBR-terminated testing

### DIFF
--- a/app/measure/measure.js
+++ b/app/measure/measure.js
@@ -194,34 +194,34 @@ angular.module('Measure.Measure', ['ngRoute'])
           {
             client_name: "speed-measurementlab-net",
             client_session_id: sid,
-            client_max_cwnd_gain: "512",
             client_immediate_exit: true,
+            max_cwnd_gain: "512",
           },
           {
             client_name: "speed-measurementlab-net",
             client_session_id: sid,
-            client_max_elapsed_time: "5",
             client_immediate_exit: true,
+            max_elapsed_time: "5",
           },
           {
             client_name: "speed-measurementlab-net",
             client_session_id: sid,
-            client_max_cwnd_gain: "512",
-            client_max_elapsed_time: "5",
             client_immediate_exit: true,
+            max_cwnd_gain: "512",
+            max_elapsed_time: "5",
           },
           {
             client_name: "speed-measurementlab-net",
             client_session_id: sid,
-            client_early_exit: "50",
             client_immediate_exit: true,
+            early_exit: "50",
           },
           {
             client_name: "speed-measurementlab-net",
             client_session_id: sid,
-            client_max_cwnd_gain: "512",
-            client_early_exit: "50",
             client_immediate_exit: true,
+            max_cwnd_gain: "512",
+            early_exit: "50",
           },
       ]
 

--- a/app/measure/measure.js
+++ b/app/measure/measure.js
@@ -190,29 +190,38 @@ angular.module('Measure.Measure', ['ngRoute'])
           {
             client_name: "speed-measurementlab-net",
             client_session_id: sid,
-            max_cwnd_gain: "512",
           },
           {
             client_name: "speed-measurementlab-net",
             client_session_id: sid,
-            max_elapsed_time: "5",
+            client_max_cwnd_gain: "512",
+            client_immediate_exit: true,
           },
           {
             client_name: "speed-measurementlab-net",
             client_session_id: sid,
-            max_cwnd_gain: "512",
-            max_elapsed_time: "5",
+            client_max_elapsed_time: "5",
+            client_immediate_exit: true,
           },
           {
             client_name: "speed-measurementlab-net",
             client_session_id: sid,
-            early_exit: "50",
+            client_max_cwnd_gain: "512",
+            client_max_elapsed_time: "5",
+            client_immediate_exit: true,
           },
           {
             client_name: "speed-measurementlab-net",
             client_session_id: sid,
-            max_cwnd_gain: "512",
-            early_exit: "50",
+            client_early_exit: "50",
+            client_immediate_exit: true,
+          },
+          {
+            client_name: "speed-measurementlab-net",
+            client_session_id: sid,
+            client_max_cwnd_gain: "512",
+            client_early_exit: "50",
+            client_immediate_exit: true,
           },
       ]
 


### PR DESCRIPTION
This PR adds the `client_immediate_exit` parameter to the set of comparison tests for BBR termination. 

It also adds a single full test to the randomized set to analyze full test data with 100ms snapshots.

I will wait until the latest k8s-support rollout is complete to merge.